### PR TITLE
Fixed several minor mistakes in the tutorial 1-2.

### DIFF
--- a/doc/Tutorial1.rst
+++ b/doc/Tutorial1.rst
@@ -37,7 +37,7 @@ There are three steps involved:
 Adding a data source
 ====================
 
-Create the file :file:`Tutorial1.py` in the :file:`python` subdirectory and add 
+Create the file :file:`Tutorial1.py` in the :file:`trackers` subdirectory and add 
 the following code::
 
    def MyDataFunction():
@@ -81,12 +81,25 @@ Create the following rst file:`Tutorial1.rst`::
 The :term:`report` directive is used to insert the graph into 
 the restructured text document. Behind the scenes, sphinxreport`sphinx` will call 
 the sphinxreport extension and request a barplot. The sphinxreport in 
-turn will look for a data source :meth:``MyDataFunction`` in the module :file:``Tutorial1.py`` 
-that should be somewhere in your :env:``PYTHONPATH` or added in :file:`conf.py`.
-The default location for these is in the :file:``python`` subdirectory under the main installation
-directory. The content of the ``report`` directive is the figure or table caption.
+turn will look for a data source :meth:`MyDataFunction` in the module :file:`Tutorial1.py` 
+that should be somewhere in your :env:`PYTHONPATH` or added in :file:`conf.py`.
+The default location for these is in the :file:`python` subdirectory under the main installation
+directory. The content of the :term:`report` directive is the figure or table caption.::
 
-Add a link to the contents section in the :file:`index.rst` and rebuild the sources::
+Add a link in the :file:`contents.rst` by appending a line immediately after the following::
+
+   :maxdepth: 2
+   analysis.rst
+   pipeline.rst
+
+to make it look like::
+
+   :maxdepth: 2
+   analysis.rst
+   pipeline.rst
+   Tutorial1.rst
+
+and rebuild the sources::
 
     make html
 

--- a/doc/Tutorial2.rst
+++ b/doc/Tutorial2.rst
@@ -19,7 +19,7 @@ to query for available :term:`tracks`.
 Adding a data source
 ********************
 
-Create the file :file:`Tutorial2.py` in the :file:`python` subdirectory and add 
+Create the file :file:`Tutorial2.py` in the :file:`trackers` subdirectory and add 
 the following code::
 
   from SphinxReport.Tracker import *
@@ -32,9 +32,9 @@ the following code::
       def __call__(self, track, slice = None ):
 	  return dict( (("header1", 10), ("header2", 20)),)
 
-The module sphinxreport`Trackers` is imported and the data source ``MyData`` is derived from it::
+The module sphinxreport`Trackers` is imported and the data source ``MyDataOneTrack`` is derived from it::
    
-   class MyData(Tracker):
+   class MyDataOneTrack(Tracker):
 
 The docstring::
 


### PR DESCRIPTION
Details:
(1) Minor error in the path to the first data tracker.
(2) index.rst don't exist. Use contents.rst instead.
(3) Added instruction on how to add a link into the contents.rst.
(4) Missing :file: directive for some files.
(5) Fixed some unbalanced quotation marks, and some strange quotation marks.
