### PR TITLE
Allow TrackerSQL to return Series from some TrackerSQL.get* calls

### DIFF
--- a/CGATReport/Tracker.py
+++ b/CGATReport/Tracker.py
@@ -790,9 +790,11 @@ class TrackerSQL(Tracker):
         return self.getDataFrame(self.buildStatement(stmt))
 
     def getValues(self, stmt):
-        '''return results of SQL statement as pandas dataframe.
+        '''return results of SQL statement as pandas Series.
         '''
-        return self.getDataFrame(self.buildStatement(stmt))
+        e = self.exectute(self.buildStatement(stmt))
+        col = [x[0] for x in e]
+        return pandas.Series(col)
 
     def getRow(self, stmt):
         '''return results of SQL statement as pandas dataframe.
@@ -800,9 +802,11 @@ class TrackerSQL(Tracker):
         return self.getDataFrame(self.buildStatement(stmt))
 
     def getFirstRow(self, stmt):
-        '''return results of SQL statement as pandas dataframe.
+        '''return first row of SQL statement as pandas Series.
         '''
-        return self.getDataFrame(self.buildStatement(stmt))
+        e = self.execute(self.buildStatement(stmt))
+        row = e.fetchone()
+        return pandas.Series(row)
 
 
 class TrackerSQLCheckTables(TrackerSQL):


### PR DESCRIPTION
Since the switch to CGATReport, almost all the TrackerSQL.get\* methods, which the exception of TrackerSQL.getValue are simply wrappers for TrackerSQL.getDataFrame.

What is the reasoning behind keeping the methods, but treating them as wrappers. Backwards compatibility is broken by return a DataFrame rather than a list or a dict or whatever. 

Take getValues as an example. In sphinx-report, this expected to be given a query that returned a single column, which is returned as a list. This makes sense as getValues suggests a list of values as its return. Getting a DataFrame back doesn't make sense.

I suggest as a compromise returning a pandas Series object. This can be indexed and concatenated like a dataframe (and can to concatenated with a dataframe), but will also behave like a list when asked to iterate.

In trackers I frequently do things like:

``` python

def getTracks(self):
    tracks = self.getValues('''SELECT DISTINCT track FROM my_table''')
    tracks = [some_munging_function(track) for track in tracks]
    return tracks

```

I think that this makes more sense than just returning the same DataFrame irrespective of the accessor used. In the pull-request, i've implemented this for getValues and getFirstRow. We might think about also implementing it for getRow where the index is the column titles.

Alternatively, remove the accessors as when debugging the subsequent failure it will be more obvious what has gone wrong than the get succeeding, but returning an unexpected data type. 
