### PR TITLE
Fix for enumeration of index in Renderer, Missing import statement in 

### DIFF
--- a/CGATReportPlugins/Renderer.py
+++ b/CGATReportPlugins/Renderer.py
@@ -1235,7 +1235,7 @@ class TableMatrix(TableBase, MatrixBase):
         """
         
         if self.normalize_row_labels:
-            drop = [x for x, y in enumerate(dataframe.index.names)
+            drop = [x for x, y in enumerate(dataframe.index.values)
                     if len(set(y)) == 1]
             rows = list(map(path2str, dataframe.index.droplevel(drop)))
         else:

--- a/CGATReportPlugins/Renderer.py
+++ b/CGATReportPlugins/Renderer.py
@@ -1235,7 +1235,7 @@ class TableMatrix(TableBase, MatrixBase):
         """
         
         if self.normalize_row_labels:
-            drop = [x for x, y in enumerate(dataframe.index.labels)
+            drop = [x for x, y in enumerate(dataframe.index.names)
                     if len(set(y)) == 1]
             rows = list(map(path2str, dataframe.index.droplevel(drop)))
         else:

--- a/CGATReportPlugins/Transformer.py
+++ b/CGATReportPlugins/Transformer.py
@@ -11,6 +11,7 @@ from CGATReport.Component import Component
 from CGATReport import Stats, DataTree, Utils
 
 from docutils.parsers.rst import directives
+from logging import warn
 
 # for rpy2 for data frames
 try:


### PR DESCRIPTION
Fixes an nonexistning dataframe index attribute 'labels'. Replaced by 'values'. (enumeration of df.index object should also work, as an alternative). Fixes #26 .

Missing import statement for warn method from logging removed by commit 86a979a2852057c73dec2943b6c16da9c15b29fd. Changing all warning messages to self.warn might also work, but not sure.