### PR TITLE
Quote spaces in filenames for xls

### DIFF
--- a/CGATReport/Plugins/XLSPlugin/__init__.py
+++ b/CGATReport/Plugins/XLSPlugin/__init__.py
@@ -27,7 +27,8 @@ class XLSPlugin(Collector):
                 self.template_name, re.sub("/", "@", block.title))
             outputpath = os.path.join(self.outdir, '%s.%s' %
                                       (outname, extension))
-
+            outputpath = re.sub(" ", "_", outputpath)
+            
             # save to file
             block.xls.save(outputpath)
 


### PR DESCRIPTION
Substitutes `_` for spaces in xlsx file names as sphinx was stripping them out of the links (but not the actaul files the link point to ). This probably needs implementing somewhere else, where it would apply across other file types, but I can't work out where would be best. 
